### PR TITLE
Coerces datetime of scenario runtime to character to preserve it's va…

### DIFF
--- a/app.R
+++ b/app.R
@@ -119,17 +119,18 @@ server <- function(input, output, session) {
         execute_params = list(
           scenario_1 = input$scenario_1,
           scenario_1_runtime = 
-            as.numeric(
+            as.character(
               lubridate::as_datetime(
                 input$scenario_1_runtime
               )
             ),
           scenario_2 = input$scenario_2,
-          scenario_2_runtime = as.numeric(
-            lubridate::as_datetime(
-              input$scenario_2_runtime 
+          scenario_2_runtime = 
+            as.character(
+              lubridate::as_datetime(
+                input$scenario_2_runtime 
+              )
             )
-          )
         ))
       output$quarto_summary <- renderUI({
         includeHTML("scenario_analysis_summary.html")


### PR DESCRIPTION
…lue upon quarto_render.

The runtime param provided to `quarto_render()` is now provided as a datetime string, this should prevent `quarto_render()` from treating it like a number. 

This interaction was previously causing the filtering of `nhp_model_runs` to return `NULL` as `scenario_*_runtime` was being changed by `quarto_render()` and ultimately not matching the expected `create_datetime` in `nhp_model_runs`. This would cause a fatal error when attempting to render the quarto file inside of the app.

The app should now render the quarto file as expected.