### PR TITLE
shows model version of selected scenarios and a warning message if th…

### DIFF
--- a/app.R
+++ b/app.R
@@ -72,12 +72,24 @@ server <- function(input, output, session) {
             "(",
             lubridate::as_datetime(input$scenario_1_runtime),
             ")"),
+          paste0("(model version: ", 
+                 nhp_model_runs |> 
+                   dplyr::filter(scenario == input$scenario_1,
+                                 create_datetime == input$scenario_1_runtime) |> 
+                   pull(app_version),
+                 ")"),
           "and",
           input$scenario_2,
           paste0(
             "(",
             lubridate::as_datetime(input$scenario_2_runtime),
             ")"),
+          paste0("(model version: ", 
+                 nhp_model_runs |> 
+                   dplyr::filter(scenario == input$scenario_2,
+                                 create_datetime == input$scenario_2_runtime) |> 
+                   pull(app_version),
+                 ")"),
           "from the scheme",
           input$selected_scheme)
   })
@@ -106,6 +118,17 @@ server <- function(input, output, session) {
     if (!starts_match || !ends_match) {
       warnings <- c(warnings, "Warning: The start and end years of the selected scenarios must match.")
     }
+    
+    if ((nhp_model_runs |> 
+        dplyr::filter(scenario == input$scenario_1,
+                      create_datetime == input$scenario_1_runtime) |> 
+        pull(app_version)) != 
+        (nhp_model_runs |> 
+         dplyr::filter(scenario == input$scenario_2,
+                       create_datetime == input$scenario_2_runtime) |> 
+         pull(app_version))){
+      warnings <- c(warnings, "Warning: Selected scenarios must have been built on the same version of the model.")
+      }
     
     # collapse into a single string, separated by new lines
     HTML(paste(warnings, collapse = "<br>"))


### PR DESCRIPTION
…e model versions are different.

This doesn't prevent users from comparing scenarios with different model_versions. @ghobro do we want something more strict than this?

Currently this looks for scenarios sharing the exact app_version, is this the functionality we want?
Or should users be allowed to compare scenarios if they have the same major app_version? (e.g. v1.0 and v1.2 can be compared)