### PR TITLE
Comments out dev loading of result sets.

### DIFF
--- a/R/app_server.R
+++ b/R/app_server.R
@@ -17,12 +17,12 @@ lapply(paste0('R/nhp_outputs/',file_names_nhs_output), source)
 
 #this should be commented out in live versions
 
-nhp_model_runs <- readRDS("inst/app/tmp_runs_file.rds") |> #tmp_runs_file.rds is an rds of the output of get_nhp_result_sets()
-  dplyr::filter(!app_version == "dev") 
+#nhp_model_runs <- readRDS("inst/app/tmp_runs_file.rds") |> #tmp_runs_file.rds is an rds of the output of get_nhp_result_sets()
+#  dplyr::filter(!app_version == "dev") 
 
 app_server = function(input, output, session) {
- # nhp_model_runs <- get_nhp_result_sets() |>
-   # dplyr::filter(!app_version == "dev")
+ nhp_model_runs <- get_nhp_result_sets() |>
+ dplyr::filter(!app_version == "dev")
   
   
   shiny::observe(


### PR DESCRIPTION
Comments out the dev loading of results sets (by reading a local RDS before app_server is created)
And re-enables live version of loading result sets (by connecting to Azure and pulling results after app_server is created)